### PR TITLE
#272 US41 Cadastrar Repositório de  Organização

### DIFF
--- a/api/github/tests/test_user.py
+++ b/api/github/tests/test_user.py
@@ -68,7 +68,6 @@ class TestUser(BaseTestCase):
                                             mocked_message,
                                             mocked_get):
         mocked_get.side_effect = (self.mocked_valid_own_data,
-                                  self.mocked_valid_own_data,
                                   self.mocked_valid_get_repo)
         mocked_post.return_value = self.mocked_post_valid
         mocked_message.return_value = Mock()
@@ -90,8 +89,7 @@ class TestUser(BaseTestCase):
 
     @patch('github.utils.github_utils.get')
     def test_view_get_repos(self, mocked_get):
-        mocked_get.side_effect = (self.mocked_valid_own_data,
-                                  self.mocked_valid_get_repo)
+        mocked_get.return_value = (self.mocked_valid_get_repo)
         response = self.client.get("/user/repositories/{chat_id}"
                                    .format(chat_id=self.user.chat_id))
         data = json.loads(response.data.decode())

--- a/api/github/user/utils.py
+++ b/api/github/user/utils.py
@@ -17,9 +17,6 @@ ACCESS_TOKEN = os.getenv("ACCESS_TOKEN", "")
 class UserInfo(GitHubUtils):
     def __init__(self, chat_id):
         super().__init__(chat_id)
-        self.headers = {
-            "Content-Type": "application/json"
-        }
 
     def get_own_user_data(self):
         url = self.GITHUB_API_URL + "user?access_token="\
@@ -31,10 +28,7 @@ class UserInfo(GitHubUtils):
         return github_data
 
     def get_repositories(self):
-        requested_username = self.get_own_user_data()
-        username = requested_username["github_username"]
-        url = self.GITHUB_API_URL + "users/{login}/repos".format(
-                                     login=username)
+        url = self.GITHUB_API_URL + "user/repos"
         requested_repositories = self.request_url(url, "get")
         project_repositories = self.repository_requested_repository(
                                     requested_repositories)


### PR DESCRIPTION
Neste pull request se realizou:
  * US 41;
  * Mudança no método de obtenção dos repositórios do gitlab para obter os repositórios de organização do GitHub;
  * Teste Unitário;
  * Folha de estilo de acordo com o padrão Python pep8.